### PR TITLE
Add global toaster component

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import { GeistSans } from 'geist/font/sans'
 import { GeistMono } from 'geist/font/mono'
 import { Analytics } from '@vercel/analytics/next'
+import { Toaster } from '@/components/ui/toaster'
 import './globals.css'
 
 export const metadata: Metadata = {
@@ -20,6 +21,7 @@ export default function RootLayout({
       <body className={`font-sans ${GeistSans.variable} ${GeistMono.variable}`}>
         {children}
         <Analytics />
+        <Toaster />
       </body>
     </html>
   )


### PR DESCRIPTION
## Summary
- import the shared toaster component into the root layout
- render the toaster alongside analytics so notifications mount on every page

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0b5df99648320815b80ba1608770a