### PR TITLE
Refine success handling for bulk notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Bulk Messaging App
+
+This project provides a simple UI for delivering notifications to many recipients over email or SMS.
+
+## API responses
+
+Both `/api/send-emails` and `/api/send-sms` return a JSON payload shaped like:
+
+```
+{
+  "success": boolean,
+  "sent": number,
+  "failed": number,
+  "message": string,
+  "results": Array<...>
+}
+```
+
+The `success` flag is `true` only when no recipients fail (`failed === 0`). When one or more recipients cannot be reached the request still returns `200 OK`, but `success` becomes `false` so callers can distinguish partial failures. A human-readable `message` summarises the send attempt alongside the per-recipient `results` array.
+
+| Endpoint | Success message | Partial failure message |
+| --- | --- | --- |
+| `/api/send-emails` | `Sent N email(s) successfully.` | `Sent N email(s) with M failure(s).` |
+| `/api/send-sms` | `Sent N SMS message(s) successfully.` | `Sent N SMS message(s) with M failure(s).` |
+
+Clients should inspect the `success` flag (rather than HTTP status) to determine whether every recipient was contacted successfully.

--- a/app/api/send-emails/route.tsx
+++ b/app/api/send-emails/route.tsx
@@ -96,11 +96,16 @@ export async function POST(request: NextRequest) {
 
     const successCount = results.filter((r) => r.status === "sent").length
     const failCount = results.filter((r) => r.status === "failed").length
+    const success = failCount === 0
+    const message = success
+      ? `Sent ${successCount} ${successCount === 1 ? "email" : "emails"} successfully.`
+      : `Sent ${successCount} ${successCount === 1 ? "email" : "emails"} with ${failCount} failure${failCount === 1 ? "" : "s"}.`
 
     return NextResponse.json({
-      success: true,
+      success,
       sent: successCount,
       failed: failCount,
+      message,
       results,
     })
   } catch (error) {

--- a/app/api/send-sms/route.ts
+++ b/app/api/send-sms/route.ts
@@ -59,11 +59,16 @@ export async function POST(request: NextRequest) {
 
     const successCount = results.filter((r) => r.status === "sent").length
     const failCount = results.filter((r) => r.status === "failed").length
+    const success = failCount === 0
+    const message = success
+      ? `Sent ${successCount} ${successCount === 1 ? "SMS message" : "SMS messages"} successfully.`
+      : `Sent ${successCount} ${successCount === 1 ? "SMS message" : "SMS messages"} with ${failCount} failure${failCount === 1 ? "" : "s"}.`
 
     return NextResponse.json({
-      success: true,
+      success,
       sent: successCount,
       failed: failCount,
+      message,
       results,
     })
   } catch (error) {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,6 +7,26 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Textarea } from "@/components/ui/textarea"
 import { X, Plus, Mail, Phone, Send, Loader2 } from "lucide-react"
 
+type ApiResponse = {
+  success?: boolean
+  sent?: number
+  failed?: number
+  message?: string
+  error?: string
+}
+
+async function parseApiResponse(response: Response): Promise<ApiResponse | null> {
+  try {
+    return (await response.json()) as ApiResponse
+  } catch {
+    return null
+  }
+}
+
+function pluralize(count: number, singular: string, plural: string) {
+  return count === 1 ? singular : plural
+}
+
 export default function BulkMessagingApp() {
   const [emails, setEmails] = useState<string[]>([""])
   const [phoneNumbers, setPhoneNumbers] = useState<string[]>([""])
@@ -73,13 +93,13 @@ export default function BulkMessagingApp() {
           content: emailContent,
         }),
       })
+      const emailData: ApiResponse = (await parseApiResponse(emailResponse)) ?? {}
 
       // Send SMS only if we have enough phone numbers and content
-      let smsAttempted = false
-      let smsOk = false
+      let smsResponse: Response | null = null
+      let smsData: ApiResponse | null = null
       if (validPhoneNumbers.length >= 2 && smsContent.trim()) {
-        smsAttempted = true
-        const smsResponse = await fetch("/api/send-sms", {
+        smsResponse = await fetch("/api/send-sms", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
@@ -87,18 +107,56 @@ export default function BulkMessagingApp() {
             content: smsContent,
           }),
         })
-        smsOk = smsResponse.ok
+        smsData = await parseApiResponse(smsResponse)
       }
 
       if (!emailResponse.ok) {
-        setStatus("❌ Failed to send emails. Check server logs for details.")
-      } else if (smsAttempted && !smsOk) {
-        setStatus(`✅ Emails sent to ${validEmails.length} recipients. ⚠️ SMS had failures.`)
-      } else if (smsAttempted && smsOk) {
-        setStatus(`✅ Successfully sent ${validEmails.length} emails and ${validPhoneNumbers.length} SMS messages!`)
-      } else {
-        setStatus(`✅ Successfully sent ${validEmails.length} emails.`)
+        const errorMessage = emailData.error
+        setStatus(`❌ Failed to send emails${errorMessage ? `: ${errorMessage}` : "."}`)
+        return
       }
+
+      const statusParts: string[] = []
+      const emailSentCount = emailData.sent ?? validEmails.length
+      const emailFailedCount = emailData.failed ?? 0
+
+      if (emailData.success === false) {
+        const emailMessage =
+          emailData.message ??
+          `Sent ${emailSentCount} ${pluralize(emailSentCount, "email", "emails")} with ${emailFailedCount} failure${
+            emailFailedCount === 1 ? "" : "s"
+          }.`
+        statusParts.push(`⚠️ ${emailMessage}`)
+      } else {
+        const emailMessage =
+          emailData.message ??
+          `Sent ${emailSentCount} ${pluralize(emailSentCount, "email", "emails")} successfully.`
+        statusParts.push(`✅ ${emailMessage}`)
+      }
+
+      if (smsResponse) {
+        if (!smsResponse.ok) {
+          const errorMessage = smsData?.error
+          statusParts.push(`❌ SMS failed${errorMessage ? `: ${errorMessage}` : "."}`)
+        } else if (smsData?.success === false) {
+          const smsSentCount = smsData.sent ?? 0
+          const smsFailedCount = smsData.failed ?? 0
+          const smsMessage =
+            smsData.message ??
+            `Sent ${smsSentCount} ${pluralize(smsSentCount, "SMS message", "SMS messages")} with ${smsFailedCount} failure${
+              smsFailedCount === 1 ? "" : "s"
+            }.`
+          statusParts.push(`⚠️ ${smsMessage}`)
+        } else {
+          const smsSentCount = smsData?.sent ?? validPhoneNumbers.length
+          const smsMessage =
+            smsData?.message ??
+            `Sent ${smsSentCount} ${pluralize(smsSentCount, "SMS message", "SMS messages")} successfully.`
+          statusParts.push(`✅ ${smsMessage}`)
+        }
+      }
+
+      setStatus(statusParts.join(" "))
     } catch (error) {
       setStatus("❌ Error sending messages. Please try again.")
       console.error("Send error:", error)


### PR DESCRIPTION
## Summary
- mark bulk email API requests as successful only when no recipients fail and add a summary message
- mirror the same success calculation for the SMS API so Twilio rejections flip the success flag
- surface the new semantics in the UI status messaging and document the response shape

## Testing
- pnpm lint *(fails: Next.js prompts for initial ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68d0b60600448320bbf312196a925b79