### PR TITLE
Improve toast feedback and status handling

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState } from "react"
+import { toast } from "@/hooks/use-toast"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
@@ -63,44 +64,164 @@ export default function BulkMessagingApp() {
     setIsLoading(true)
     setStatus("Sending messages...")
 
-    try {
-      // Send emails
-      const emailResponse = await fetch("/api/send-emails", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          emails: validEmails,
-          content: emailContent,
-        }),
-      })
+    const getFailureMessages = (results: unknown) => {
+      if (!Array.isArray(results)) return [] as string[]
 
-      // Send SMS only if we have enough phone numbers and content
-      let smsAttempted = false
-      let smsOk = false
-      if (validPhoneNumbers.length >= 2 && smsContent.trim()) {
-        smsAttempted = true
-        const smsResponse = await fetch("/api/send-sms", {
+      const uniqueMessages = new Set<string>()
+      for (const entry of results) {
+        if (
+          entry &&
+          typeof entry === "object" &&
+          "status" in entry &&
+          (entry as { status?: string }).status === "failed" &&
+          "error" in entry &&
+          typeof (entry as { error?: unknown }).error === "string" &&
+          (entry as { error: string }).error.trim()
+        ) {
+          uniqueMessages.add((entry as { error: string }).error)
+        }
+      }
+
+      return Array.from(uniqueMessages)
+    }
+
+    const parseCount = (value: unknown) =>
+      typeof value === "number" && Number.isFinite(value) ? value : 0
+
+    const describeCounts = (sent: number, failed: number, label: string) => {
+      if (failed > 0) {
+        return `${label}: ${sent} sent, ${failed} failed`
+      }
+      return `${label}: ${sent} sent successfully`
+    }
+
+    let emailStatusMessage = ""
+    let smsStatusMessage = ""
+
+    try {
+      try {
+        const emailResponse = await fetch("/api/send-emails", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
-            phoneNumbers: validPhoneNumbers,
-            content: smsContent,
+            emails: validEmails,
+            content: emailContent,
           }),
         })
-        smsOk = smsResponse.ok
+
+        const emailData = await emailResponse.json()
+        const emailSentCount = parseCount((emailData as { sent?: unknown })?.sent)
+        const emailFailedCount = parseCount((emailData as { failed?: unknown })?.failed)
+        const emailFailures = getFailureMessages((emailData as { results?: unknown })?.results)
+
+        if (!emailResponse.ok || (emailData as { success?: unknown })?.success === false) {
+          const errorMessage =
+            (typeof (emailData as { error?: unknown })?.error === "string" &&
+            (emailData as { error: string }).error.trim()
+              ? (emailData as { error: string }).error
+              : emailFailures.join(" • ") || "Failed to send emails.")
+
+          toast({
+            title: "Email request failed",
+            description: errorMessage,
+            variant: "destructive",
+          })
+          emailStatusMessage = `Emails: ${errorMessage}`
+        } else if (emailFailedCount > 0) {
+          const failureSummary = emailFailures.join(" • ") || "Some emails failed to send."
+          toast({
+            title: "Email delivery issues",
+            description: failureSummary,
+            variant: "destructive",
+          })
+          emailStatusMessage = describeCounts(emailSentCount, emailFailedCount, "Emails")
+        } else {
+          toast({
+            title: "Emails sent",
+            description: `Delivered ${emailSentCount} email${emailSentCount === 1 ? "" : "s"} successfully.`,
+          })
+          emailStatusMessage = describeCounts(emailSentCount, emailFailedCount, "Emails")
+        }
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : "Unexpected error sending emails."
+        toast({
+          title: "Email request error",
+          description: message,
+          variant: "destructive",
+        })
+        emailStatusMessage = `Emails: ${message}`
+        console.error("Email send error:", error)
       }
 
-      if (!emailResponse.ok) {
-        setStatus("❌ Failed to send emails. Check server logs for details.")
-      } else if (smsAttempted && !smsOk) {
-        setStatus(`✅ Emails sent to ${validEmails.length} recipients. ⚠️ SMS had failures.`)
-      } else if (smsAttempted && smsOk) {
-        setStatus(`✅ Successfully sent ${validEmails.length} emails and ${validPhoneNumbers.length} SMS messages!`)
-      } else {
-        setStatus(`✅ Successfully sent ${validEmails.length} emails.`)
+      if (validPhoneNumbers.length >= 2 && smsContent.trim()) {
+        try {
+          const smsResponse = await fetch("/api/send-sms", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              phoneNumbers: validPhoneNumbers,
+              content: smsContent,
+            }),
+          })
+
+          const smsData = await smsResponse.json()
+          const smsSentCount = parseCount((smsData as { sent?: unknown })?.sent)
+          const smsFailedCount = parseCount((smsData as { failed?: unknown })?.failed)
+          const smsFailures = getFailureMessages((smsData as { results?: unknown })?.results)
+
+          if (!smsResponse.ok || (smsData as { success?: unknown })?.success === false) {
+            const errorMessage =
+              (typeof (smsData as { error?: unknown })?.error === "string" &&
+              (smsData as { error: string }).error.trim()
+                ? (smsData as { error: string }).error
+                : smsFailures.join(" • ") || "Failed to send SMS messages.")
+
+            toast({
+              title: "SMS request failed",
+              description: errorMessage,
+              variant: "destructive",
+            })
+            smsStatusMessage = `SMS: ${errorMessage}`
+          } else if (smsFailedCount > 0) {
+            const failureSummary = smsFailures.join(" • ") || "Some SMS messages failed to send."
+            toast({
+              title: "SMS delivery issues",
+              description: failureSummary,
+              variant: "destructive",
+            })
+            smsStatusMessage = describeCounts(smsSentCount, smsFailedCount, "SMS")
+          } else {
+            toast({
+              title: "SMS sent",
+              description: `Delivered ${smsSentCount} SMS message${smsSentCount === 1 ? "" : "s"} successfully.`,
+            })
+            smsStatusMessage = describeCounts(smsSentCount, smsFailedCount, "SMS")
+          }
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : "Unexpected error sending SMS messages."
+          toast({
+            title: "SMS request error",
+            description: message,
+            variant: "destructive",
+          })
+          smsStatusMessage = `SMS: ${message}`
+          console.error("SMS send error:", error)
+        }
       }
+
+      const statusParts = [emailStatusMessage, smsStatusMessage].filter(Boolean)
+      setStatus(statusParts.join(" • "))
     } catch (error) {
-      setStatus("❌ Error sending messages. Please try again.")
+      const message =
+        error instanceof Error ? error.message : "Unexpected error sending messages."
+      toast({
+        title: "Bulk send failed",
+        description: message,
+        variant: "destructive",
+      })
+      setStatus(`❌ Error sending messages: ${message}`)
       console.error("Send error:", error)
     } finally {
       setIsLoading(false)


### PR DESCRIPTION
## Summary
- import the toast helper on the bulk messaging page and parse API JSON payloads after each request
- show success toasts when deliveries succeed and destructive toasts with detailed failure reasons when problems occur
- update the inline status banner to summarize parsed email and SMS results instead of assuming a successful HTTP response

## Testing
- pnpm lint *(fails: prompts for interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68d0b5ef46c083209337542c9d48f899